### PR TITLE
Minor wording tweaks to pages.

### DIFF
--- a/geni-auth.js
+++ b/geni-auth.js
@@ -11,7 +11,7 @@ genilib.authorize = function(id, cert, callback, defaultMA)
                               '?id=' +
                               encodeURIComponent(id),
                               'GENI Tool Authorization',
-                              'height=400,width=800');
+                              'height=500,width=800');
 
   wrapper.listener = function (event) {
     var data;

--- a/template/authorize.html
+++ b/template/authorize.html
@@ -1,7 +1,7 @@
 <div class="hero-unit">
   <h1>GENI Authorization Tool</h1>
-  <p>The GENI Authorization Tool allows you to authorize applications to speak on your behalf to allocate slices or slivers. Your credentials are stored locally in your browser and your passphrase is never transmitted over the network.</p>
-  <p class="tool-info">To authorize, enter the passphrase for your GENI certificate below. Once you authorize, the tool will be able to act on your behalf when talking to GENI infrastructure. Only authorize if you trust the tool.</p>
+  <p>The GENI Authorization Tool allows you to authorize applications to speak on your behalf to allocate slices or slivers. Your GENI certificate and private key are stored in your web browser and your passphrase is never transmitted over the network.</p>
+  <p class="tool-info">To authorize, enter the passphrase for your GENI private key below. Once you authorize, the tool will be able to act on your behalf when talking to GENI infrastructure. Only authorize if you trust the tool.</p>
   <h5 class="tool-info">Tool URN: <%= id %></h5>
   <div class="tool-info" id="error-box"></div>
   <form class="tool-info form-horizontal" role="form" id="private">

--- a/template/no-key.html
+++ b/template/no-key.html
@@ -1,7 +1,7 @@
 <div class="hero-unit">
   <h1>GENI Authorization Tool</h1>
-  <p>The GENI Authorization Tool allows you to authorize applications to speak on your behalf to allocate slices or slivers. Your credentials are stored locally in your browser and your passphrase is never transmitted over the network.</p>
-  <p>Your GENI certificate is not yet setup. Please choose your Slice Authority from the list below to fetch your certificate.</p>
+  <p>The GENI Authorization Tool allows you to authorize applications to speak on your behalf to allocate slices or slivers. Your GENI certificate and private key are stored in your web browser and your passphrase is never transmitted over the network.</p>
+  <p>You can download your GENI certificate and private key from a GENI Member Authority or paste your GENI certificate and private key into the box below.</p>
   <form id="sa-form" class="form-horizontal">
     <div class="form-group">
       <label class="control-label col-lg-2" for="sa-choice">Member Authority</label>
@@ -13,7 +13,7 @@
     </div>
     <div class="form-group">
       <div class="col-offset-2 col-lg-10">
-        <button id="sa-button" class="btn btn-default">Get Certificate</button>
+        <button id="sa-button" class="btn btn-default">Download Certificate</button>
       </div>
     </div>
   </form>
@@ -22,7 +22,7 @@
     <div class="form-group">
       <label class="control-label col-lg-2" for="paste-input">Paste Certificate</label>
       <div class="col-lg-10">
-        <textarea id="paste-input" class="form-control" rows="10" placeholder="Paste Certificate and Key Here..."></textarea>
+        <textarea id="paste-input" class="form-control" rows="10" placeholder="Paste Certificate and Private Key Here..."></textarea>
       </div>
     </div>
     <div class="form-group">


### PR DESCRIPTION
Use consistent language, make the initial signer tool window larger so
it fits.
