### PR TITLE
PKCS#8 and Release 1.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([xml-signer], [1.1], [https://github.com/duerig/xml-signer/issues],, [https://github.com/duerig/xml-signer])
+AC_INIT([xml-signer], [1.2], [https://github.com/duerig/xml-signer/issues],, [https://github.com/duerig/xml-signer])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror])
 AC_PROG_MKDIR_P
 AC_PROG_INSTALL

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ xml-signer (1.2) unstable; urgency=low
 
   * Support PKCS#8 private keys
 
- -- Tom Mitchell <tmitchell@bbn.com>  Fri, 17 Mar 2015 14:06:00 +0000
+ -- Tom Mitchell <tmitchel@bbn.com>  Fri, 17 Apr 2015 14:06:00 +0000
 
 xml-signer (1.1) unstable; urgency=low
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+xml-signer (1.2) unstable; urgency=low
+
+  * Support PKCS#8 private keys
+
+ -- Tom Mitchell <tmitchell@bbn.com>  Fri, 17 Mar 2015 14:06:00 +0000
+
 xml-signer (1.1) unstable; urgency=low
 
   * Styling changes

--- a/xml-signer.js
+++ b/xml-signer.js
@@ -209,18 +209,22 @@ function ($, _, error, forge, sigExport, xmlText, noKeyText, authorizeText) {
 
   function extractKey(pem)
   {
+    var pkcs1_begin = "-----BEGIN RSA PRIVATE KEY-----";
+    var pkcs1_end   = "-----END RSA PRIVATE KEY-----";
+    var pkcs8_begin = "-----BEGIN PRIVATE KEY-----";
+    var pkcs8_end   = "-----END PRIVATE KEY-----";
     var inKey = false;
     var key = "";
     var lines = pem.split('\n');
     var i = 0;
     for (i = 0; i < lines.length; i += 1)
     {
-      if (lines[i] === "-----BEGIN RSA PRIVATE KEY-----")
+      if (lines[i] === pkcs1_begin || lines[i] === pkcs8_begin)
       {
         key = lines[i] + '\n';
         inKey = true;
       }
-      else if (lines[i] === "-----END RSA PRIVATE KEY-----")
+      else if (lines[i] === pkcs1_end || lines[i] === pkcs8_end)
       {
         key += lines[i] + '\n';
         inKey = false;

--- a/xml-signer.spec
+++ b/xml-signer.spec
@@ -1,11 +1,11 @@
 Name:           xml-signer
-Version:        1.1
+Version:        1.2
 Release:        1%{?dist}
 Summary:        Credential signer for GENI
 BuildArch:      noarch
 License:        GENI Public License
 URL:            https://github.com/duerig/xml-signer
-Source0:        https://github.com/duerig/xml-signer/xml-signer-1.1.tar.gz
+Source0:        https://github.com/tcmitchell/xml-signer/xml-signer-1.2.tar.gz
 Group:          Applications/Internet
 
 # BuildRequires: gettext
@@ -123,6 +123,8 @@ rm -rf $RPM_BUILD_ROOT
 %attr(-, root, root) %{_datadir}/%{name}/www/xml-signer.js
 
 %changelog
+* Fri Apr 17 2015 Tom Mitchell <tmitchell@bbn.com> - 1.2-1%{?dist}
+- Support PKCS#8 private keys
 * Tue Mar 31 2015 Tom Mitchell <tmitchell@bbn.com> - 1.1-1%{?dist}
 - Styling changes
 * Thu Sep 25 2014 Tom Mitchell <tmitchell@bbn.com> - 1.0.1-1%{?dist}


### PR DESCRIPTION
 * Add support for PKCS#8 private keys.
 * Bump the version number to 1.2
