### PR TITLE
Add httpd config for CentOS 7

### DIFF
--- a/INSTALL.centos.in
+++ b/INSTALL.centos.in
@@ -4,11 +4,11 @@
 yum install httpd
 service httpd start
 
-2. Configure Apache to serve xml-signer
+2. Configure httpd (Apache) to serve xml-signer
 
-xml-signer ships with a sample Apache configuration file:
+xml-signer ships with a sample CentOS 7 httpd configuration file:
 
-  @pkgdatadir@/etc/apache2.conf
+  @pkgdatadir@/etc/httpd-centos7.conf
 
 You can use this file in several ways to add xml-signer to your Apache
 configuration. If you want to serve it globally you can simply create
@@ -16,15 +16,15 @@ a link in /etc/httpd/conf.d to the sample xml-signer Apache
 configuration file:
 
   # Add file or link in /etc/httpd/conf.d
-  ln -s @pkgdatadir@/etc/apache2.conf /etc/httpd/conf.d/xml-signer.conf
+  ln -s @pkgdatadir@/etc/httpd-centos7.conf /etc/httpd/conf.d/xml-signer.conf
 
 Alternatively, if you want more control over how xml-signer is served,
-you can include the sample xml-signer Apache configuration file in an
+you can include the sample xml-signer httpd configuration file in an
 appropriate Apache configuration file. For instance, if you want to
 server xml-signer only via ssl, add the following line inside the
 VirtualHost definition in /etc/httpd/conf.d/ssl.conf:
 
-  Include @pkgdatadir@/etc/apache2.conf
+  Include @pkgdatadir@/etc/httpd-centos7.conf
 
 Finally, you can serve xml-signer from a location of your choosing by
 copying the contents of the sample xml-signer Apache configuration

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,7 @@ edit = sed \
 	-e 's|@pkgsysconfdir[@]|$(pkgsysconfdir)|g' \
 	-e 's|@prefix[@]|$(prefix)|g'
 
-INSTALL.centos etc/apache2.conf: Makefile
+INSTALL.centos etc/apache2.conf etc/httpd-centos7.conf: Makefile
 	rm -f $@ $@.tmp
 	srcdir=''; \
 	  test -f ./$@.in || srcdir=$(srcdir)/; \
@@ -22,6 +22,7 @@ INSTALL.centos etc/apache2.conf: Makefile
 	mv $@.tmp $@
 
 etc/apache2.conf: $(srcdir)/etc/apache2.conf.in
+etc/httpd-centos7.conf: $(srcdir)/etc/httpd-centos7.conf.in
 INSTALL.centos: $(srcdir)/INSTALL.centos.in
 
 # Distribute these but do not install them
@@ -29,14 +30,17 @@ EXTRA_DIST = \
 	INSTALL.centos.in \
 	debian \
 	xml-signer.spec \
-	etc/apache2.conf.in
+	etc/apache2.conf.in \
+	etc/httpd-centos7.conf.in
 
 CLEANFILES = \
 	etc/apache2.conf \
+	etc/httpd-centos7.conf \
 	INSTALL.centos
 
 nobase_pkgdata_DATA = \
-	etc/apache2.conf
+	etc/apache2.conf \
+	etc/httpd-centos7.conf
 
 # Put all the files for the web server under 'www' for easy apache
 # configuration.

--- a/etc/httpd-centos7.conf.in
+++ b/etc/httpd-centos7.conf.in
@@ -1,0 +1,5 @@
+Alias /xml-signer @pkgdatadir@/www
+<Directory @pkgdatadir@/www>
+  AllowOverride None
+  Require all granted
+</Directory>

--- a/xml-signer.spec
+++ b/xml-signer.spec
@@ -44,6 +44,7 @@ rm -rf $RPM_BUILD_ROOT
 %attr(-, root, root) %{_defaultdocdir}/%{name}/README.md
 %attr(-, root, root) %{_defaultdocdir}/%{name}/copyright
 %attr(-, root, root) %{_datadir}/%{name}/etc/apache2.conf
+%attr(-, root, root) %{_datadir}/%{name}/etc/httpd-centos7.conf
 %attr(-, root, root) %{_datadir}/%{name}/www/emulab.html
 %attr(-, root, root) %{_datadir}/%{name}/www/emulab.js
 %attr(-, root, root) %{_datadir}/%{name}/www/error.js


### PR DESCRIPTION
CentOS 7 uses a newer Apache whose permissions directives are slightly
different from those used by Apache in CentOS 6 and Ubuntu 12. Offer
a new sample config tailored to CentOS 7 in addition to the existing
sample configuration file.